### PR TITLE
Feature/formatting timestamp

### DIFF
--- a/amibaker/ami_baker.py
+++ b/amibaker/ami_baker.py
@@ -3,6 +3,7 @@ import time
 from jinja2 import Template
 from .ami_ec2 import AmiEc2
 from .provisioner import Provisioner
+from .util import EpochDateTime
 
 
 class AmiBaker:
@@ -36,7 +37,7 @@ class AmiBaker:
         else:
             self.__recipe['ec2_tags'] = dict(Name=self.__recipe['ami_tags']['Name'])
 
-        timestamp = int(time.time())
+        timestamp = EpochDateTime.now()
 
         render(self.__recipe['ec2_tags'], timestamp=timestamp)
         render(self.__recipe['ami_tags'], timestamp=timestamp)

--- a/amibaker/ami_baker.py
+++ b/amibaker/ami_baker.py
@@ -1,5 +1,4 @@
 import yaml
-import time
 from jinja2 import Template
 from .ami_ec2 import AmiEc2
 from .provisioner import Provisioner

--- a/amibaker/provisioner.py
+++ b/amibaker/provisioner.py
@@ -2,6 +2,7 @@ from fabric.api import env, settings, hide
 from fabric.operations import run, put, sudo
 from os import path
 
+
 class Provisioner:
     def __init__(self, ec2, **kwargs):
         self.__ec2 = ec2

--- a/amibaker/util.py
+++ b/amibaker/util.py
@@ -1,0 +1,14 @@
+import datetime
+
+class EpochDateTime(datetime.datetime):
+    """
+    Very simple class to override the datetime.datetime's __str__ function
+    so that it returns the epoch time instead of the default
+    """
+    
+    def __init__(self, *args, **kwargs):
+        self.epoch_dt = datetime.datetime(1970,1,1)
+        super(EpochDateTime, self).__init__(*args, **kwargs)
+
+    def __str__(self):
+        return '{0:.0f}'.format((self - self.epoch_dt).total_seconds())

--- a/amibaker/util.py
+++ b/amibaker/util.py
@@ -1,13 +1,14 @@
 import datetime
 
+
 class EpochDateTime(datetime.datetime):
     """
     Very simple class to override the datetime.datetime's __str__ function
     so that it returns the epoch time instead of the default
     """
-    
+
     def __init__(self, *args, **kwargs):
-        self.epoch_dt = datetime.datetime(1970,1,1)
+        self.epoch_dt = datetime.datetime(1970, 1, 1)
         super(EpochDateTime, self).__init__(*args, **kwargs)
 
     def __str__(self):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ tox==2.1.1
 nose2==0.5.0
 nose2-cov==1.0a4
 mock==1.0.1
+-r requirements.txt

--- a/tests/test_amibaker.py
+++ b/tests/test_amibaker.py
@@ -2,6 +2,7 @@ import unittest
 
 import StringIO
 from argparse import Namespace
+from functools import partial
 
 from amibaker.ami_baker import AmiBaker
 
@@ -25,8 +26,9 @@ key_name: my_key
 associate_public_ip: no
 
         ''')
-        with self.assertRaises(ValueError):
-            a = AmiBaker(fake_recipe)
+
+        failing_instantiator = partial(AmiBaker, fake_recipe)
+        self.assertRaises(ValueError, failing_instantiator)
 
     def test_base_ami_in_recipie(self):
         fake_recipe = StringIO.StringIO(b'''

--- a/tests/test_amibaker.py
+++ b/tests/test_amibaker.py
@@ -1,10 +1,10 @@
 import unittest
 
 import StringIO
-from argparse import Namespace
 from functools import partial
 
 from amibaker.ami_baker import AmiBaker
+
 
 class TestAmiBaker(unittest.TestCase):
     def setUp(self):
@@ -45,7 +45,6 @@ associate_public_ip: no
         ''')
         a = AmiBaker(fake_recipe)
         assert a._AmiBaker__recipe['base_ami'] == 'ami-deadbeef'
-
 
     def test_base_ami_overridden(self):
         fake_recipe = StringIO.StringIO(b'''

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -34,7 +34,7 @@ class TestProvisioner(unittest.TestCase):
                          'mode': mode[i]})
 
         with contextlib.nested(
-                patch('amibaker.provisioner.put', return_value=True),
+                patch('amibaker.provisioner.put', return_value=True),  # NOQA
                 patch('amibaker.provisioner.sudo', return_value=True)
             ) as (put, sudo):
             self.provisioner._Provisioner__copy(copy)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,50 @@
+import time
+import datetime 
+import unittest
+import StringIO
+
+from amibaker.util import EpochDateTime
+
+from amibaker.ami_baker import AmiBaker
+
+class TestEpochDateTime(unittest.TestCase):
+
+    def test_str_is_like_a_epoch_timestamp(self):
+        mark = int(time.time())
+        edt = EpochDateTime.now()
+        result = edt.__str__()
+        assert result >= result
+        assert '.' not in result
+
+    def test_strftime_still_works(self):
+        assert datetime.datetime.now().strftime('%Y-%m-%d') == \
+            EpochDateTime.now().strftime('%Y-%m-%d')
+
+    def test_rendertags_timestamp_default(self):
+        mark = int(time.time())
+        fake_recipe = StringIO.StringIO(b'''
+base_ami: whatever
+ami_tags:
+  Name: ROFL {{ timestamp }} LOL
+        ''')
+        a = AmiBaker(fake_recipe)
+        result = a._AmiBaker__recipe['ami_tags']['Name'].split()
+        assert result[0] == 'ROFL'
+        assert '.' not in result[1]
+        assert int(result[1]) >= mark
+        assert result[2] == 'LOL'
+
+    def test_rendertags_timestamp_strftime(self):
+        mark = datetime.datetime.now()
+        fake_recipe = StringIO.StringIO(b'''
+base_ami: whatever
+ami_tags:
+  Name: ROFL {{ timestamp.strftime('%Y-%m-%d %H:%M:%S') }} LOL
+        ''')
+        a = AmiBaker(fake_recipe)
+        result = a._AmiBaker__recipe['ami_tags']['Name'].split()
+        assert result[0] == 'ROFL'
+        assert int(result[1].split('-')[0]) == mark.year
+        assert int(result[1].split('-')[1]) == mark.month
+        assert int(result[1].split('-')[2]) == mark.day
+        assert result[3] == 'LOL'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
 import time
-import datetime 
+import datetime
 import unittest
 import StringIO
 
@@ -7,13 +7,14 @@ from amibaker.util import EpochDateTime
 
 from amibaker.ami_baker import AmiBaker
 
+
 class TestEpochDateTime(unittest.TestCase):
 
     def test_str_is_like_a_epoch_timestamp(self):
         mark = int(time.time())
         edt = EpochDateTime.now()
         result = edt.__str__()
-        assert result >= result
+        assert result >= mark
         assert '.' not in result
 
     def test_strftime_still_works(self):

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,4 @@ deps =
 
 [flake8]
 exclude = build/*
+max-line-length = 160


### PR DESCRIPTION
For date/time formatting feature request #9 
Subclassed datetime.datetime to override it's str call
Tests cover changed functionality and integration with AmiBaker.__render_tags.
Changed test_amibaker so that it should work with py26.
General flake8 cleanup.
